### PR TITLE
Refactor twig component syntax

### DIFF
--- a/src/TwigComponent/src/Twig/ComponentLexer.php
+++ b/src/TwigComponent/src/Twig/ComponentLexer.php
@@ -25,18 +25,10 @@ use Twig\TokenStream;
  */
 class ComponentLexer extends Lexer
 {
-    public const ATTRIBUTES_REGEX = '(?<attributes>(?:\s+[\w\-:.@]+(=(?:\\\"[^\\\"]*\\\"|\'[^\']*\'|[^\'\\\"=<>]+))?)*\s*)';
-    public const OPEN_TAGS_REGEX = '/<\s*t:(?<name>([[\w\-\:\.]+))\s*'.self::ATTRIBUTES_REGEX.'(\s?)+>/';
-    public const CLOSE_TAGS_REGEX = '/<\/\s*t:([\w\-\:\.]+)\s*>/';
-    public const SELF_CLOSE_TAGS_REGEX = '/<\s*t:(?<name>([\w\-\:\.]+))\s*'.self::ATTRIBUTES_REGEX.'(\s?)+\/>/';
-    public const BLOCK_TAGS_OPEN = '/<\s*t:block\s+name=("|\')(?<name>([\w\-\:\.]+))("|\')\s*>/';
-    public const BLOCK_TAGS_CLOSE = '/<\s*\/\s*t:block\s*>/';
-    public const ATTRIBUTE_BAG_REGEX = '/(?:^|\s+)\{\{\s*(attributes(?:.+?(?<!\s))?)\s*\}\}/x';
-    public const ATTRIBUTE_KEY_VALUE_REGEX = '/(?<attribute>[\w\-:.@]+)(=(?<value>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+)))?/x';
-
     public function tokenize(Source $source): TokenStream
     {
-        $preparsed = $this->preparsed($source->getCode());
+        $preLexer = new TwigPreLexer();
+        $preparsed = $preLexer->preLexComponents($source->getCode());
 
         return parent::tokenize(
             new Source(
@@ -45,125 +37,5 @@ class ComponentLexer extends Lexer
                 $source->getPath()
             )
         );
-    }
-
-    private function preparsed(string $value)
-    {
-        $value = $this->lexBlockTags($value);
-        $value = $this->lexBlockTagsClose($value);
-        $value = $this->lexSelfCloseTag($value);
-        $value = $this->lexOpeningTags($value);
-        $value = $this->lexClosingTag($value);
-
-        return $value;
-    }
-
-    private function lexOpeningTags(string $value)
-    {
-        return preg_replace_callback(
-            self::OPEN_TAGS_REGEX,
-            function (array $matches) {
-                $name = $matches['name'];
-                $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
-
-                return '{% component '.$name.' with '.$attributes.'%}';
-            },
-            $value
-        );
-    }
-
-    private function lexClosingTag(string $value)
-    {
-        return preg_replace(self::CLOSE_TAGS_REGEX, '{% endcomponent %}', $value);
-    }
-
-    private function lexSelfCloseTag(string $value)
-    {
-        return preg_replace_callback(
-            self::SELF_CLOSE_TAGS_REGEX,
-            function (array $matches) {
-                $name = $matches['name'];
-                $attributes = $this->getAttributesFromAttributeString($matches['attributes']);
-
-                return "{{ component('".$name."', ".$attributes.') }}';
-            },
-            $value
-        );
-    }
-
-    private function lexBlockTags(string $value)
-    {
-        return preg_replace_callback(
-            self::BLOCK_TAGS_OPEN,
-            function (array $matches) {
-                $name = $matches['name'];
-
-                return '{% block '.$name.' %}';
-            },
-            $value
-        );
-    }
-
-    private function lexBlockTagsClose(string $value)
-    {
-        return preg_replace(
-            self::BLOCK_TAGS_CLOSE,
-            '{% endblock %}',
-            $value
-        );
-    }
-
-    protected function getAttributesFromAttributeString(string $attributeString)
-    {
-        $attributeString = $this->parseAttributeBag($attributeString);
-
-        if (!preg_match_all(self::ATTRIBUTE_KEY_VALUE_REGEX, $attributeString, $matches, \PREG_SET_ORDER)) {
-            return '{}';
-        }
-
-        $attributes = [];
-        foreach ($matches as $match) {
-            $attribute = $match['attribute'];
-            $value = $match['value'] ?? null;
-
-            if (null === $value) {
-                $value = 'true';
-            }
-
-            if (str_starts_with($attribute, ':')) {
-                $attribute = str_replace(':', '', $attribute);
-                $value = $this->stripQuotes($value);
-            }
-
-            $valueWithoutQuotes = $this->stripQuotes($value);
-
-            if (str_starts_with($valueWithoutQuotes, '{{') && (strpos($valueWithoutQuotes, '}}') === \strlen($valueWithoutQuotes) - 2)) {
-                $value = substr($valueWithoutQuotes, 2, -2);
-            } else {
-                $value = $value;
-            }
-
-            $attributes[$attribute] = $value;
-        }
-
-        $out = '{';
-        foreach ($attributes as $key => $value) {
-            $key = "'$key'";
-            $out .= "$key: $value,";
-        }
-
-        return rtrim($out, ',').'}';
-    }
-
-    public function stripQuotes(string $value)
-    {
-        return str_starts_with($value, '"') || str_starts_with($value, '\'')
-            ? substr($value, 1, -1)
-            : $value;
-    }
-
-    protected function parseAttributeBag(string $attributeString)
-    {
-        return preg_replace(self::ATTRIBUTE_BAG_REGEX, ' :attributes="$1"', $attributeString);
     }
 }

--- a/src/TwigComponent/src/Twig/TwigPreLexer.php
+++ b/src/TwigComponent/src/Twig/TwigPreLexer.php
@@ -1,0 +1,287 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Twig;
+
+/**
+ * Rewrites <twig:component> syntaxes to {% component %} syntaxes.
+ */
+class TwigPreLexer
+{
+    private string $input;
+    private int $length;
+    private int $position = 0;
+    private int $line;
+    /** @var string[] */
+    private array $currentComponents = [];
+
+    public function __construct(int $startingLine = 1)
+    {
+        $this->line = $startingLine;
+    }
+
+    public function preLexComponents(string $input): string
+    {
+        $this->input = $input;
+        $this->length = strlen($input);
+        $output = '';
+
+        while ($this->position < $this->length) {
+            if ($this->consume('<t:')) {
+                $componentName = $this->consumeComponentName();
+
+                if ($componentName === 'block') {
+                    $output .= $this->consumeBlock();
+
+                    continue;
+                }
+
+                $attributes = $this->consumeAttributes();
+                $isSelfClosing = $this->consume('/>');
+                if (!$isSelfClosing) {
+                    $this->consume('>');
+                    $this->currentComponents[] = $componentName;
+                }
+
+                $output .= "{% component {$componentName}" . ($attributes ? " with { {$attributes} }" : '') . " %}";
+                if ($isSelfClosing) {
+                    $output .= '{% endcomponent %}';
+                }
+
+                continue;
+            }
+
+            if (!empty($this->currentComponents) && $this->check('</t:')) {
+                $this->consume('</t:');
+                $closingComponentName = $this->consumeComponentName();
+                $this->consume('>');
+
+                $lastComponent = array_pop($this->currentComponents);
+
+                if ($closingComponentName !== $lastComponent) {
+                    throw new \RuntimeException("Expected closing tag '</t:{$lastComponent}>' but found '</t:{$closingComponentName}>' at line {$this->line}");
+                }
+
+                $output .= "{% endcomponent %}";
+
+                continue;
+            }
+
+            $char = $this->consumeChar();
+            if ($char === "\n") {
+                $this->line++;
+            }
+            $output .= $char;
+        }
+
+        return $output;
+    }
+
+    private function consumeComponentName(): string
+    {
+        $start = $this->position;
+        while ($this->position < $this->length && preg_match('/[A-Za-z0-9_]/', $this->input[$this->position])) {
+            $this->position++;
+        }
+        $componentName = substr($this->input, $start, $this->position - $start);
+
+        if (empty($componentName)) {
+            throw new \RuntimeException("Expected component name at line {$this->line}");
+        }
+
+        return $componentName;
+    }
+
+    private function consumeAttributes(): string
+    {
+        $attributes = [];
+
+        while ($this->position < $this->length && !$this->check('>') && !$this->check('/>')) {
+            $this->consumeWhitespace();
+            if ($this->check('>') || $this->check('/>')) {
+                break;
+            }
+
+            $isAttributeDynamic = false;
+
+            // :someProp="dynamicVar"
+            if ($this->check(':')) {
+                $this->consume(':');
+                $isAttributeDynamic = true;
+            }
+
+            $key = $this->consumeComponentName();
+
+            // <t:component someProp> -> someProp: true
+            if (!$this->check('=')) {
+                $attributes[] = sprintf("%s: true", $key);
+                $this->consumeWhitespace();
+                continue;
+            }
+
+            $this->expectAndConsumeChar('=');
+            $quote = $this->consumeChar(["'", '"']);
+
+            // someProp="{{ dynamicVar }}"
+            if ($this->consume('{{')) {
+                $this->consumeWhitespace();
+                $attributeValue = rtrim($this->consumeUntil('}'));
+                $this->expectAndConsumeChar('}');
+                $this->expectAndConsumeChar('}');
+                $this->consumeUntil($quote);
+                $isAttributeDynamic = true;
+            } else {
+                $attributeValue = $this->consumeUntil($quote);
+            }
+            $this->expectAndConsumeChar($quote);
+
+            if ($isAttributeDynamic) {
+                $attributes[] = sprintf("%s: %s", $key, $attributeValue);
+            } else {
+                $attributes[] = sprintf("%s: '%s'", $key, str_replace("'", "\'", $attributeValue));
+            }
+
+            $this->consumeWhitespace();
+        }
+
+        return implode(', ', $attributes);
+    }
+
+    private function consume(string $string): bool
+    {
+        if (substr($this->input, $this->position, strlen($string)) === $string) {
+            $this->position += strlen($string);
+            return true;
+        }
+
+        return false;
+    }
+
+    private function consumeChar($validChars = null): string
+    {
+        if ($this->position >= $this->length) {
+            throw new \RuntimeException("Unexpected end of input");
+        }
+
+        $char = $this->input[$this->position];
+
+        if ($validChars !== null && !in_array($char, (array)$validChars, true)) {
+            throw new \RuntimeException("Expected one of [" . implode('', (array)$validChars) . "] but found '{$char}' at line {$this->line}");
+        }
+
+        $this->position++;
+
+        return $char;
+    }
+
+    private function consumeUntil(string $endString): string
+    {
+        $start = $this->position;
+        $endCharLength = strlen($endString);
+
+        while ($this->position < $this->length) {
+            if (substr($this->input, $this->position, $endCharLength) === $endString) {
+                break;
+            }
+
+            if ($this->input[$this->position] === "\n") {
+                $this->line++;
+            }
+            $this->position++;
+        }
+
+        return substr($this->input, $start, $this->position - $start);
+    }
+
+    private function consumeWhitespace(): void
+    {
+        while ($this->position < $this->length && preg_match('/\s/', $this->input[$this->position])) {
+            if ($this->input[$this->position] === "\n") {
+                $this->line++;
+            }
+            $this->position++;
+        }
+    }
+
+    /**
+     * Checks that the next character is the one given and consumes it.
+     */
+    private function expectAndConsumeChar(string $char): void
+    {
+        if (strlen($char) !== 1) {
+            throw new \InvalidArgumentException('Expected a single character');
+        }
+
+        if ($this->position >= $this->length || $this->input[$this->position] !== $char) {
+            throw new \RuntimeException("Expected '{$char}' but found '{$this->input[$this->position]}' at line {$this->line}");
+        }
+        $this->position++;
+    }
+
+    private function check(string $chars): bool
+    {
+        $charsLength = strlen($chars);
+        if ($this->position + $charsLength > $this->length) {
+            return false;
+        }
+
+        for ($i = 0; $i < $charsLength; $i++) {
+            if ($this->input[$this->position + $i] !== $chars[$i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function consumeBlock(): string
+    {
+        $attributes = $this->consumeAttributes();
+        $this->consume('>');
+
+        $blockName = '';
+        foreach (explode(', ', $attributes) as $attr) {
+            list($key, $value) = explode(': ', $attr);
+            if ($key === 'name') {
+                $blockName = trim($value, "'");
+                break;
+            }
+        }
+
+        if (empty($blockName)) {
+            throw new \RuntimeException("Expected block name at line {$this->line}");
+        }
+
+        $output = "{% block {$blockName} %}";
+
+        $closingTag = "</t:block>";
+        if (!$this->doesStringEventuallyExist($closingTag)) {
+            throw new \RuntimeException("Expected closing tag '{$closingTag}' for block '{$blockName}' at line {$this->line}");
+        }
+        $blockContents = $this->consumeUntil($closingTag);
+
+        $subLexer = new self($this->line);
+        $output .= $subLexer->preLexComponents($blockContents);
+
+        $this->consume($closingTag);
+        $output .= "{% endblock %}";
+
+        return $output;
+    }
+
+    private function doesStringEventuallyExist(string $needle): bool
+    {
+        $remainingString = substr($this->input, $this->position);
+
+        return str_contains($remainingString, $needle);
+    }
+}
+

--- a/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
+++ b/src/TwigComponent/tests/Unit/TwigPreLexerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\UX\TwigComponent\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\UX\TwigComponent\Twig\TwigPreLexer;
+
+final class TwigPreLexerTest extends TestCase
+{
+    /**
+     * @dataProvider getLexTests
+     */
+    public function testPreLex(string $input, string $expectedOutput): void
+    {
+        $lexer = new TwigPreLexer();
+        $this->assertSame($expectedOutput, $lexer->preLexComponents($input));
+    }
+
+    public function getLexTests(): iterable
+    {
+        yield 'simple_component' => [
+            '<t:foo />',
+            "{% component foo %}{% endcomponent %}",
+        ];
+
+        yield 'component_with_attributes' => [
+            '<t:foo bar="baz" with_quotes="It\'s with quotes" />',
+            "{% component foo with { bar: 'baz', with_quotes: 'It\'s with quotes' } %}{% endcomponent %}",
+        ];
+
+        yield 'component_with_dynamic_attributes' => [
+            '<t:foo dynamic="{{ dynamicVar }}" :otherDynamic="anotherVar" />',
+            "{% component foo with { dynamic: dynamicVar, otherDynamic: anotherVar } %}{% endcomponent %}",
+        ];
+
+        yield 'component_with_closing_tag' => [
+            '<t:foo></t:foo>',
+            "{% component foo %}{% endcomponent %}",
+        ];
+
+        yield 'component_with_block' => [
+            '<t:foo><t:block name="foo_block">Foo</t:block></t:foo>',
+            "{% component foo %}{% block foo_block %}Foo{% endblock %}{% endcomponent %}",
+        ];
+
+        yield 'component_with_embedded_component_inside_block' => [
+            '<t:foo><t:block name="foo_block"><t:bar /></t:block></t:foo>',
+            "{% component foo %}{% block foo_block %}{% component bar %}{% endcomponent %}{% endblock %}{% endcomponent %}",
+        ];
+
+        yield 'attribute_with_no_value' => [
+            '<t:foo bar />',
+            "{% component foo with { bar: true } %}{% endcomponent %}",
+        ];
+    }
+}


### PR DESCRIPTION
Hi!

Thanks again for getting this rolling! The regex was working great, but it didn't give us any opportunity to give the user a good error if they make a small mistake. This is an attempt to rewrite the logic without regex. It's possible I've missed something (though tests pass). And probably a lot more edge case tests could be added & probably we should try to "mess up" Twig syntax a bunch of times to make sure we get good errors (and ideally write tests for those errors).

This also adds the concept of a "default" block:

```
<t:successAlert type="{{ alertType }}">
    <p>It's a small world after all</p>
    <t:successAlert type="success">Inception!</t:successAlert>

    <t:block name="some_other_block">
        Not used
    </t:block>
</t:successAlert>
```

In this case, the content that is NOT inside the `<t:block` (so the `<p>` tag + the embedded `<t:successAlert type="success">Inception!</t:successAlert>`) become part of a new block called `default`:

```
<div{{ attributes.defaults({class: 'alert alert-'~type}) }}>
    {% block default %}{% endblock %}
</div>
```

🔥 